### PR TITLE
Update indriya dependency

### DIFF
--- a/unitfx/pom.xml
+++ b/unitfx/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>tech.units</groupId>
             <artifactId>indriya</artifactId>
-            <version>2.1.2</version>
+            <version>2.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
With an update of GemsFX from 2.8.0 to 2.9.0, I got

    Error occurred during initialization of boot layer
    java.lang.module.FindException: Module javax.inject not found, required by tech.units.indriya

Updating tech.units.indriya from 2.1.2 to 2.2 solved the issue.

(Released: https://github.com/unitsofmeasurement/indriya/releases)

And we can soon celebrate [World Refrigeration Day](https://worldrefrigerationday.org/) :)

